### PR TITLE
Fix reliance on having message actions expanded

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,7 +1,10 @@
 // actions.js - Handles message manipulation and UI actions for Message_Collapser
 
+import { getContext } from "../../../extensions.js";
+
 export const arrowClass = 'message-collapser-arrow';
 export const collapsedClass = 'message-collapser-message-collapsed';
+let chat = getContext().chat
 
 // Function to add collapse/expand arrows to messages
 export function addCollapseArrowsToMessages() {
@@ -19,6 +22,36 @@ export function addCollapseArrowsToMessages() {
 export function removeCollapseArrowsFromMessages() {
     console.log("Message Collapser: Removing collapse arrows.");
     $('.' + arrowClass).remove();
+}
+
+// Function to collapse message
+function collapseMessage(mes_id) {
+    const message = $('.mes[mesid="'+mes_id+'"]');
+
+    const messageText = message.find('.mes_text');
+    const arrowSpan = message.find('.' + arrowClass);
+    const icon = arrowSpan.find('i');
+
+    messageText.hide();
+    message.addClass(collapsedClass);
+    if (arrowSpan.length && icon.length) {
+        icon.removeClass('fa-chevron-down').addClass('fa-chevron-right');
+    }
+}
+
+// Function to expand message
+function expandMessage(mes_id) {
+    const message = $('.mes[mesid="'+mes_id+'"]');
+
+    const messageText = message.find('.mes_text');
+    const arrowSpan = message.find('.' + arrowClass);
+    const icon = arrowSpan.find('i');
+
+    messageText.show();
+    message.removeClass(collapsedClass);
+    if (arrowSpan.length && icon.length) {
+        icon.removeClass('fa-chevron-right').addClass('fa-chevron-down');
+    }
 }
 
 // Handler for clicking an arrow
@@ -39,70 +72,37 @@ export function handleArrowClick(event) {
 }
 
 export function handleCollapseDisabledClick() {
-    const disabledSelectorString = "$('.mes_unhide.fa-eye-slash:visible').closest('.mes')";
-    const $disabledMessages = $('.mes_unhide.fa-eye-slash:visible').closest('.mes');
-    const $allMessages = $('.mes');
-
-
-    if ($disabledMessages.length === 0) {
-        toastr.info("No 'hidden' messages (with visible .mes_unhide.fa-eye-slash) found to collapse.");
-        return;
-    }
-
     let count = 0;
-    $disabledMessages.each(function(index) {
-        const message = $(this);
-
-        const messageText = message.find('.mes_text');
-        const arrowSpan = message.find('.' + arrowClass);
-        const icon = arrowSpan.find('i');
-
-        messageText.hide();
-        message.addClass(collapsedClass);
-        if (arrowSpan.length && icon.length) {
-            icon.removeClass('fa-chevron-down').addClass('fa-chevron-right');
+    for (var mes_id = 0; mes_id < chat.length; mes_id++) {
+        // the is_system attribute is actually whether the message is included in the prompt, i.e. hidden
+        if (chat[mes_id].is_system) {
+            collapseMessage(mes_id);
+            count++;
         }
-        count++;
-    });
+    }
 
     if (count > 0) {
         toastr.success(count + (count === 1 ? " 'hidden' message collapsed." : " 'hidden' messages collapsed."));
     } else {
-        toastr.info("No 'hidden' messages found to collapse (post-loop check).");
+        toastr.info("No 'hidden' messages found to collapse.");
     }
+
 }
 
 export function handleExpandDisabledClick() {
-    const disabledSelectorString = "$('.mes_unhide.fa-eye-slash:visible').closest('.mes')";
-    const $disabledMessages = $('.mes_unhide.fa-eye-slash:visible').closest('.mes');
-    const $allMessages = $('.mes');
-
-
-    if ($disabledMessages.length === 0) {
-        toastr.info("No 'hidden' messages (with visible .mes_unhide.fa-eye-slash) found to expand.");
-        return;
-    }
-
     let count = 0;
-    $disabledMessages.each(function(index) {
-        const message = $(this);
-
-        const messageText = message.find('.mes_text');
-        const arrowSpan = message.find('.' + arrowClass);
-        const icon = arrowSpan.find('i');
-
-        messageText.show();
-        message.removeClass(collapsedClass);
-        if (arrowSpan.length && icon.length) {
-            icon.removeClass('fa-chevron-right').addClass('fa-chevron-down');
+    for (var mes_id = 0; mes_id < chat.length; mes_id++) {
+        // the is_system attribute is actually whether the message is included in the prompt, i.e. hidden
+        if (chat[mes_id].is_system) {
+            expandMessage(mes_id);
+            count++;
         }
-        count++;
-    });
+    }
 
     if (count > 0) {
         toastr.success(count + (count === 1 ? " 'hidden' message expanded." : " 'hidden' messages expanded."));
     } else {
-        toastr.info("No 'hidden' messages found to expand (post-loop check).");
+        toastr.info("No 'hidden' messages found to expand.");
     }
 }
 


### PR DESCRIPTION
Changes the check from DOM element visibility to the actual message property flagging it as hidden. I also pulled out the collapse/expand logic into reusable functions instead of embedded anonymous functions so they could feasibly be used elsewhere.